### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,6 +47,8 @@ jobs:
   test:
     needs: compile
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       max-parallel: 2


### PR DESCRIPTION
Potential fix for [https://github.com/mishmash-io/for-apache/security/code-scanning/3](https://github.com/mishmash-io/for-apache/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `test` job in the workflow file. Since the `test` job does not require write permissions, we can set the permissions to `contents: read`. This ensures that the job has the minimal permissions necessary to execute its tasks.

Steps to implement the fix:
1. Locate the `test` job definition in the `.github/workflows/maven.yml` file.
2. Add a `permissions` block under the `test` job, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
